### PR TITLE
added bswap

### DIFF
--- a/prospector.c
+++ b/prospector.c
@@ -35,7 +35,7 @@ enum hf_type {
     HF32_ADD,  // x += const32
     HF32_ROT,  // x  = (x << const5) | (x >> (32 - const5))
     HF32_NOT,  // x  = ~x
-    HF32_BSWAP, //x  = bswap32(x)
+    HF32_BSWAP,// x  = bswap32(x)
     HF32_XORL, // x ^= x << const5
     HF32_XORR, // x ^= x >> const5
     HF32_ADDL, // x += x << const5


### PR DESCRIPTION
While looking for some changes in another project's hashing function, I came across your page and your blog. Great work! 

Actually, I currently am using the prospector to find some maybe unique hashing function… but perhaps, I will just lazily fall-back to your `lowbias32()` or `triple32()`.

However, I found that the famous endianess-changer (bijective, fast on many platforms) has still been missing in the prospector. So, this pull request adds 32-bit and 64-bit byte-swap as `bswap`. The C-code output prints out the `__builtin` intrinsics – I found `le64toh(htobe64(x));` to be a less readable alternative.

Digging for gold, it has not brought me any luck yet. But, who knows…

`./prospector -p bswap -L -4 | more`'s output indicate that it is working well, also with `-8`.