### PR TITLE
added byte shuffle

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,13 +294,21 @@ x ^= x >> constant;
 x ^= x << constant;
 x += x << constant;
 x -= x << constant;
-x <<<= constant; // left rotation
+x <<<= constant;  // left rotation
+bswap(x);         // byte swap - the endianess changer 
+shf(x, constant); // byte shuffle, permutation
 ```
 
 Technically `x = ~x` is covered by `x = ^= constant`. However, `~x` is
 uniquely special and particularly useful. The generator is very unlikely
 to generate the one correct constant for the XOR operator that achieves
 the same effect.
+
+`shf` uses the SSSE3 byte shuffle instruction and only is available on
+corresponding hardware; `03020100` denotes identity (no permute), `00010203`
+equals the endianess changing byte swap. 64-bit hashes optioanlly take a
+permutation of `{ 00, ...  , 07 }` such as `0304050607020100`; all hex 
+without leading `0x`.
 
 ## 16-bit hashes
 


### PR DESCRIPTION
This pull request adds a byte shuffle `shf` to hash prospector for 32-bit as well as 64-bit hashing functions.

It relies on SSSE3's `pshufb` instruction and only works on corresponding hardware which should comprise most recent Intel/AMD CPUs. All related additions to the code are guarded by `#ifdef`s.

`-p`-provided patterns can use `shf` or `shf:<perm>` where `perm` denotes a permutation of the byte positions. In 32-bit mode, `shf:03020100` describes identity, i.e. no change of position, and `shf:00010203` equals an endianess changing byte swap. In 64-bit mode (`-8`), those permutations need to be longer, e.g. `shf:0605040302010007` corresponding to an 8-bit left rotate. A sole `shf` employs a randomly generated permutation.